### PR TITLE
Fix: remove TypeScript catch annotation for Netlify build

### DIFF
--- a/frontend/app/admin/artworks/page.tsx
+++ b/frontend/app/admin/artworks/page.tsx
@@ -44,8 +44,12 @@ export default function ManageArtworksPage() {
 				...d
 			}))
 			setItems(normalized)
-	+	} catch (err: any) {
-			toast.error(err.message || "Error loading artworks")
+		} catch (err) {
+			if (err instanceof Error) {
+				toast.error(err.message || "Error loading artworks")
+			} else {
+				toast.error("Error loading artworks")
+			}
 		} finally {
 			setLoading(false)
 		}
@@ -73,8 +77,12 @@ export default function ManageArtworksPage() {
 			setNewQty(1)
 			toast.success("Artwork created")
 			fetchItems()
-		} catch (err: any) {
-			toast.error(err.message || "Create failed")
+		} catch (err) {
+			if (err instanceof Error) {
+				toast.error(err.message || "Create failed")
+			} else {
+				toast.error("Create failed")
+			}
 		} finally {
 			setCreating(false)
 		}
@@ -97,8 +105,12 @@ export default function ManageArtworksPage() {
 			toast.success("Artwork updated")
 			setEditItem(null)
 			fetchItems()
-		} catch (err: any) {
-			toast.error(err.message || "Update failed")
+		} catch (err) {
+			if (err instanceof Error) {
+				toast.error(err.message || "Update failed")
+			} else {
+				toast.error("Update failed")
+			}
 		} finally {
 			setUpdatingId(null)
 		}
@@ -111,8 +123,12 @@ export default function ManageArtworksPage() {
 			if (!res.ok && res.status !== 204) throw new Error("Failed to delete")
 			toast.success("Artwork deleted")
 			fetchItems()
-		} catch (err: any) {
-			toast.error(err.message || "Delete failed")
+		} catch (err) {
+			if (err instanceof Error) {
+				toast.error(err.message || "Delete failed")
+			} else {
+				toast.error("Delete failed")
+			}
 		} finally {
 			setDeletingId(null)
 		}
@@ -224,10 +240,7 @@ export default function ManageArtworksPage() {
 															</div>
 														</div>
 														<DialogFooter>
-															<Button
-																onClick={saveEdit}
-																disabled={updatingId === it.id}
-															>
+															<Button onClick={saveEdit} disabled={updatingId === it.id}>
 																{updatingId === it.id ? "Saving..." : "Save changes"}
 															</Button>
 														</DialogFooter>
@@ -252,5 +265,3 @@ export default function ManageArtworksPage() {
 		</div>
 	)
 }
-
-


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove TypeScript `any` type annotation from catch blocks

- Add proper error type checking with `instanceof Error`

- Provide fallback error messages for non-Error exceptions

- Clean up formatting and remove trailing whitespace


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["catch err: any"] -- "Remove any annotation" --> B["catch err"]
  B -- "Add type guard" --> C["if err instanceof Error"]
  C -- "Safe access" --> D["err.message"]
  C -- "Fallback" --> E["Generic message"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Improve error handling with proper type checking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/app/admin/artworks/page.tsx

<ul><li>Replaced <code>catch (err: any)</code> with <code>catch (err)</code> in four async functions<br> <li> Added <code>instanceof Error</code> type guards before accessing <code>err.message</code><br> <li> Implemented fallback error messages for non-Error caught values<br> <li> Removed unnecessary line breaks and trailing whitespace<br> <li> Reformatted multi-line Button component to single line</ul>


</details>


  </td>
  <td><a href="https://github.com/kalviumcommunity/S76_Sandanam_Capstone_OopsArt/pull/11/files#diff-ba9478cdb99e2e3e59f613633c50026737e76fe37b8767758488413c5da20fa3">+25/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

